### PR TITLE
fix: legacy syndication now subsribes to OsloIdAssigned

### DIFF
--- a/src/StreetNameRegistry.Projections.Legacy/StreetNameSyndication/StreetNameSyndicationProjections.cs
+++ b/src/StreetNameRegistry.Projections.Legacy/StreetNameSyndication/StreetNameSyndicationProjections.cs
@@ -27,6 +27,15 @@ namespace StreetNameRegistry.Projections.Legacy.StreetNameSyndication
                     .AddAsync(streetNameSyndicationItem, ct);
             });
 
+            When<Envelope<StreetNameOsloIdWasAssigned>>(async (context, message, ct) =>
+            {
+                await context.CreateNewStreetNameSyndicationItem(
+                    message.Message.StreetNameId,
+                    message,
+                    x => x.OsloId = message.Message.OsloId,
+                    ct);
+            });
+
             When<Envelope<StreetNameNameWasNamed>>(async (context, message, ct) =>
             {
                 await context.CreateNewStreetNameSyndicationItem(

--- a/src/StreetNameRegistry/StreetName/Events/StreetNameOsloIdWasAssigned.cs
+++ b/src/StreetNameRegistry/StreetName/Events/StreetNameOsloIdWasAssigned.cs
@@ -2,16 +2,18 @@ namespace StreetNameRegistry.StreetName.Events
 {
     using System;
     using Be.Vlaanderen.Basisregisters.EventHandling;
+    using Be.Vlaanderen.Basisregisters.GrAr.Provenance;
     using Newtonsoft.Json;
     using NodaTime;
 
     [EventName("StreetNameOsloIdWasAssigned")]
     [EventDescription("De straatnaam kreeg een Oslo Id toegekend.")]
-    public class StreetNameOsloIdWasAssigned : IHasStreetNameId
+    public class StreetNameOsloIdWasAssigned : IHasStreetNameId, IHasProvenance, ISetProvenance
     {
         public Guid StreetNameId { get; }
         public int OsloId { get; }
         public Instant AssignmentDate { get; }
+        public ProvenanceData Provenance { get; private set; }
 
         public StreetNameOsloIdWasAssigned(
             StreetNameId streetNameId,
@@ -27,9 +29,13 @@ namespace StreetNameRegistry.StreetName.Events
         private StreetNameOsloIdWasAssigned(
             Guid streetNameId,
             int osloId,
-            Instant assignmentDate) :
+            Instant assignmentDate,
+            ProvenanceData provenance) :
             this(new StreetNameId(streetNameId),
                 new OsloId(osloId),
-                new OsloAssignmentDate(assignmentDate)) { }
+                new OsloAssignmentDate(assignmentDate))
+            => ((ISetProvenance)this).SetProvenance(provenance.ToProvenance());
+
+        void ISetProvenance.SetProvenance(Provenance provenance) => Provenance = new ProvenanceData(provenance);
     }
 }


### PR DESCRIPTION
The syndication projection of the Legacy runner now subscribes to StreetNameOsloIdWasAssigned.
Provenance was added to StreetNameOsloIdWasAssigned.