### PR TITLE
fix: correct migration script GRAR-1442

### DIFF
--- a/src/StreetNameRegistry.Projections.Legacy/Migrations/20200703102824_AddSyndicationItemCreatedAt.cs
+++ b/src/StreetNameRegistry.Projections.Legacy/Migrations/20200703102824_AddSyndicationItemCreatedAt.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace StreetNameRegistry.Projections.Legacy.Migrations
@@ -7,12 +7,21 @@ namespace StreetNameRegistry.Projections.Legacy.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // set value to UtcNow for all existing records
             migrationBuilder.AddColumn<DateTimeOffset>(
                 name: "SyndicationItemCreatedAt",
                 schema: "StreetNameRegistryLegacy",
                 table: "StreetNameSyndication",
                 nullable: false,
-                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+                defaultValue: DateTimeOffset.UtcNow);
+
+            // remove the default value
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "SyndicationItemCreatedAt",
+                schema: "StreetNameRegistryLegacy",
+                table: "StreetNameSyndication",
+                nullable: false,
+                defaultValue: null);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
### Impact of changing the migration:
  **if migration was already excuted: default value is not removed**

- Production: migration is not yet deployed
- Staging: migration is not yet deployed
- local: verify manually if needed