### PR TITLE
test: consumer connection string should point to events table

### DIFF
--- a/test/StreetNameRegistry.Api.BackOffice.IntegrationTests/StreetNameRegistry.Api.BackOffice.IntegrationTests.csproj
+++ b/test/StreetNameRegistry.Api.BackOffice.IntegrationTests/StreetNameRegistry.Api.BackOffice.IntegrationTests.csproj
@@ -3,14 +3,8 @@
 
   <ItemGroup>
     <Content Include="appsettings.json" CopyToOutputDirectory="Always" />
-    <Content Include="sqlserver.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="appsettings.*.json" CopyToOutputDirectory="Always" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="sqlserver.yml" />
+    <Content Include="sqlserver.yml" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/StreetNameRegistry.Api.BackOffice.IntegrationTests/appsettings.json
+++ b/test/StreetNameRegistry.Api.BackOffice.IntegrationTests/appsettings.json
@@ -2,8 +2,8 @@
   "ConnectionStrings": {
     "Events": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry;TrustServerCertificate=True",
     "Snapshots": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry;TrustServerCertificate=True;",
-    "Consumer": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry;TrustServerCertificate=True",
-    "ConsumerAdmin": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry;TrustServerCertificate=True",
+    "Consumer": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry-events;TrustServerCertificate=True",
+    "ConsumerAdmin": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry-events;TrustServerCertificate=True",
     "BackOffice": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry;TrustServerCertificate=True",
     "Sequences": "Server=localhost,5434;User Id=sa;Password=Pass@word;database=streetname-registry;TrustServerCertificate=True"
   },


### PR DESCRIPTION
One of the BackOfficeContext's EF migrations has a query to the MunicipalityConsumer table. In this query the database name is hardcoded. To be able to run that migration, we should point the Consumer and ConsumerAdmin connection string to the events table, see https://github.com/Informatievlaanderen/streetname-registry/blob/main/src/StreetNameRegistry.Api.BackOffice.Abstractions/Migrations/20230417184756_AddNisCode.cs#L21