### PR TITLE
fix: don't include removed streetname in StreetNameWasRetiredBecauseO…

### DIFF
--- a/src/StreetNameRegistry/Municipality/Municipality.cs
+++ b/src/StreetNameRegistry/Municipality/Municipality.cs
@@ -97,7 +97,9 @@ namespace StreetNameRegistry.Municipality
             foreach (var streetName in currentStreetNames)
             {
                 var newStreetNamePersistentLocalIds = newMunicipality.StreetNames
-                    .Where(x => x.MergedStreetNamePersistentLocalIds.Contains(streetName.PersistentLocalId))
+                    .Where(x =>
+                        !x.IsRemoved &&
+                        x.MergedStreetNamePersistentLocalIds.Contains(streetName.PersistentLocalId))
                     .Select(x => x.PersistentLocalId)
                     .ToList();
 
@@ -111,7 +113,9 @@ namespace StreetNameRegistry.Municipality
             foreach (var streetName in proposedStreetNames)
             {
                 var newStreetNamePersistentLocalIds = newMunicipality.StreetNames
-                    .Where(x => x.MergedStreetNamePersistentLocalIds.Contains(streetName.PersistentLocalId))
+                    .Where(x =>
+                        !x.IsRemoved &&
+                        x.MergedStreetNamePersistentLocalIds.Contains(streetName.PersistentLocalId))
                     .Select(x => x.PersistentLocalId)
                     .ToList();
 

--- a/test/StreetNameRegistry.Tests/AggregateTests/Extensions/StreetNameWasProposedForMunicipalityMergerExtensions.cs
+++ b/test/StreetNameRegistry.Tests/AggregateTests/Extensions/StreetNameWasProposedForMunicipalityMergerExtensions.cs
@@ -1,0 +1,60 @@
+namespace StreetNameRegistry.Tests.AggregateTests.Extensions
+{
+    using System.Linq;
+    using Municipality;
+    using Municipality.Events;
+
+    public static class StreetNameWasProposedForMunicipalityMergerExtensions
+    {
+        public static StreetNameWasProposedForMunicipalityMerger WithPersistentLocalId(this StreetNameWasProposedForMunicipalityMerger @event,
+            PersistentLocalId id)
+        {
+            var newEvent = new StreetNameWasProposedForMunicipalityMerger(
+                new MunicipalityId(@event.MunicipalityId),
+                new NisCode(@event.NisCode),
+                @event.DesiredStatus,
+                new Names(@event.StreetNameNames),
+                new HomonymAdditions(@event.HomonymAdditions),
+                id,
+                @event.MergedStreetNamePersistentLocalIds.Select(x => new PersistentLocalId(x)).ToList());
+
+            newEvent.SetProvenance(@event.Provenance.ToProvenance());
+
+            return newEvent;
+        }
+
+        public static StreetNameWasProposedForMunicipalityMerger WithMunicipalityId(this StreetNameWasProposedForMunicipalityMerger @event,
+            MunicipalityId id)
+        {
+            var newEvent = new StreetNameWasProposedForMunicipalityMerger(
+                id,
+                new NisCode(@event.NisCode),
+                @event.DesiredStatus,
+                new Names(@event.StreetNameNames),
+                new HomonymAdditions(@event.HomonymAdditions),
+                new PersistentLocalId(@event.PersistentLocalId),
+                @event.MergedStreetNamePersistentLocalIds.Select(x => new PersistentLocalId(x)).ToList());
+
+            newEvent.SetProvenance(@event.Provenance.ToProvenance());
+
+            return newEvent;
+        }
+
+        public static StreetNameWasProposedForMunicipalityMerger WithMergedPersistentLocalIds(this StreetNameWasProposedForMunicipalityMerger @event,
+            params PersistentLocalId[] mergedPersistentLocalIds)
+        {
+            var newEvent = new StreetNameWasProposedForMunicipalityMerger(
+                new MunicipalityId(@event.MunicipalityId),
+                new NisCode(@event.NisCode),
+                @event.DesiredStatus,
+                new Names(@event.StreetNameNames),
+                new HomonymAdditions(@event.HomonymAdditions),
+                new PersistentLocalId(@event.PersistentLocalId),
+                mergedPersistentLocalIds.ToList());
+
+            newEvent.SetProvenance(@event.Provenance.ToProvenance());
+
+            return newEvent;
+        }
+    }
+}

--- a/test/StreetNameRegistry.Tests/AggregateTests/Extensions/StreetNameWasProposedV2Extensions.cs
+++ b/test/StreetNameRegistry.Tests/AggregateTests/Extensions/StreetNameWasProposedV2Extensions.cs
@@ -1,6 +1,5 @@
 namespace StreetNameRegistry.Tests.AggregateTests.Extensions
 {
-    using Be.Vlaanderen.Basisregisters.GrAr.Provenance;
     using Municipality;
     using Municipality.Events;
 
@@ -15,7 +14,21 @@ namespace StreetNameRegistry.Tests.AggregateTests.Extensions
                 new Names(@event.StreetNameNames),
                 id);
 
-            ((ISetProvenance)newEvent).SetProvenance(@event.Provenance.ToProvenance());
+            newEvent.SetProvenance(@event.Provenance.ToProvenance());
+
+            return newEvent;
+        }
+
+        public static StreetNameWasProposedV2 WithMunicipalityId(this StreetNameWasProposedV2 @event,
+            MunicipalityId id)
+        {
+            var newEvent = new StreetNameWasProposedV2(
+                id,
+                new NisCode(@event.NisCode),
+                new Names(@event.StreetNameNames),
+                new PersistentLocalId(@event.PersistentLocalId));
+
+            newEvent.SetProvenance(@event.Provenance.ToProvenance());
 
             return newEvent;
         }
@@ -30,7 +43,7 @@ namespace StreetNameRegistry.Tests.AggregateTests.Extensions
                 names,
                 new PersistentLocalId(@event.PersistentLocalId));
 
-            ((ISetProvenance)newEvent).SetProvenance(@event.Provenance.ToProvenance());
+            newEvent.SetProvenance(@event.Provenance.ToProvenance());
 
             return newEvent;
         }

--- a/test/StreetNameRegistry.Tests/AggregateTests/Extensions/StreetNameWasRemovedV2Extensions.cs
+++ b/test/StreetNameRegistry.Tests/AggregateTests/Extensions/StreetNameWasRemovedV2Extensions.cs
@@ -1,0 +1,34 @@
+
+namespace StreetNameRegistry.Tests.AggregateTests.Extensions
+{
+    using Be.Vlaanderen.Basisregisters.GrAr.Provenance;
+    using Municipality;
+    using Municipality.Events;
+
+    public static class StreetNameWasRemovedV2Extensions
+    {
+        public static StreetNameWasRemovedV2 WithPersistentLocalId(this StreetNameWasRemovedV2 @event,
+            PersistentLocalId id)
+        {
+            var newEvent = new StreetNameWasRemovedV2(
+                new MunicipalityId(@event.MunicipalityId),
+                id);
+
+            ((ISetProvenance)newEvent).SetProvenance(@event.Provenance.ToProvenance());
+
+            return newEvent;
+        }
+
+        public static StreetNameWasRemovedV2 WithMunicipalityId(this StreetNameWasRemovedV2 @event,
+            MunicipalityId id)
+        {
+            var newEvent = new StreetNameWasRemovedV2(
+                id,
+                new PersistentLocalId(@event.PersistentLocalId));
+
+            ((ISetProvenance)newEvent).SetProvenance(@event.Provenance.ToProvenance());
+
+            return newEvent;
+        }
+    }
+}


### PR DESCRIPTION
…fMunicipalityMerger.MergedPersistentLocalIds